### PR TITLE
FUSETOOLS2-45 - Use new Red Hat ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.0.5
 
+* Fix wsdl2rest extension reference
+
 ## 0.0.4
 
 * Update naming approved by Red Hat legal

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This extension pack installs the following Visual Studio Code extensions that ar
 
 * [Project initializer by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.project-initializer). It allows to create Apache Camel or Red Hat Fuse projects by selecting a mission.
 ![Create project](./images/CreateProjectFromTopLevelCommand.gif)
-* [Language Support for Apache Camel](https://marketplace.visualstudio.com/items?itemName=camel-tooling.vscode-apache-camel). It provides help for textual edition of Camel files (Completion, Validation, Navigation) For instance, see completion with Camel XML dsl:
+* [Language Support for Apache Camel](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-apache-camel). It provides help for textual edition of Camel files (Completion, Validation, Navigation) For instance, see completion with Camel XML dsl:
 ![completion for xml dsl](./images/completion.gif)
 * [Java Extension Pack](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack). It provides a large set of tooling for Java applications.
 * [SpringBoot extension pack](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-boot-dev-pack) It provides a large set of tooling for SpringBoot applications.
 * [OpenShift Connector](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-openshift-connector). It provides a large set of tooling to interact with an OpenShift instance.
-* [WSDL to Camel Rest DSL](https://marketplace.visualstudio.com/items?itemName=camel-tooling.vscode-wsdl2rest) It allows to kickstart a project from a wsdl.
+* [WSDL to Camel Rest DSL](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-wsdl2rest) It allows to kickstart a project from a wsdl.
 ![WSDL to Camel Rest DSL](./images/wsdl2rest.gif)

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
 		"Extension Packs"
 	],
 	"extensionPack": [
-		"camel-tooling.vscode-apache-camel",
-		"camel-tooling.vscode-wsdl2rest",
+		"redhat.vscode-apache-camel",
+		"redhat.vscode-wsdl2rest",
 		"pivotal.vscode-boot-dev-pack",
 		"redhat.project-initializer",
 		"redhat.vscode-openshift-connector",


### PR DESCRIPTION
especially useful for wsdl2rest for which the redirection is not working
or the previous version has been removed

Signed-off-by: Aurélien Pupier <apupier@redhat.com>