### PR TITLE
FUSETOOLS2-129 - Add Tooling for Apache Camel K

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.0.6
 
+* Add [Tooling for Apache Camel K](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-camelk)
+
 ## 0.0.5
 
 * Fix wsdl2rest extension reference

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This extension pack installs the following Visual Studio Code extensions that ar
 ![Create project](./images/CreateProjectFromTopLevelCommand.gif)
 * [Language Support for Apache Camel](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-apache-camel). It provides help for textual edition of Camel files (Completion, Validation, Navigation) For instance, see completion with Camel XML dsl:
 ![completion for xml dsl](./images/completion.gif)
+ [Tooling for Apache Camel K](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-camelk). It provides support for Apache Camel K, a lightweight integration platform, born on Kubernetes, with serverless superpowers.
 * [Java Extension Pack](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack). It provides a large set of tooling for Java applications.
 * [SpringBoot extension pack](https://marketplace.visualstudio.com/items?itemName=Pivotal.vscode-boot-dev-pack) It provides a large set of tooling for SpringBoot applications.
 * [OpenShift Connector](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-openshift-connector). It provides a large set of tooling to interact with an OpenShift instance.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"redhat.project-initializer",
 		"redhat.vscode-openshift-connector",
 		"redhat.vscode-xml",
-		"vscjava.vscode-java-pack"
+		"vscjava.vscode-java-pack",
+		"redhat.vscode-camelk"
 	],
 	"keywords": [
 		"Apache Camel",


### PR DESCRIPTION
given that the only mentioned blocker to integrate in the extension pack seems [undoable in middle term](https://issues.redhat.com/browse/FUSETOOLS2-128?focusedCommentId=13824322&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13824322) with VS Code capabilities, I think we will live with overcharged right-click menu.