### PR TITLE
FUSETOOLS2-745 - switching to latest LTS version of nodejs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ node('rhel7'){
 	}
 
 	stage('Install requirements') {
-		def nodeHome = tool 'nodejs-10.9.0'
+		def nodeHome = tool 'nodejs-lts'
 		env.PATH="${env.PATH}:${nodeHome}/bin"
 		sh "npm install -g typescript vsce"
 	}


### PR DESCRIPTION
The new Jenkins instance doesn't know the old 10.9.0 version and I have been asked by the maintainers to update to the latest LTS version instead which is referenced by the name `nodejs-lts` on the new instance.

Signed-off-by: Lars Heinemann <lhein.smx@gmail.com>