### PR TITLE
FUSETOOLS2-865 - follow migration guide from Travis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2.1
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: /^dependabot.*$/
+
+jobs:
+  build:
+    working_directory: ~/vscode-camel-extension-pack
+    docker:
+      - image: cimg/node:lts
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+      - run:
+          name: install-typescript
+          command: sudo npm install -g typescript
+      - run:
+          name: install-vsce
+          command: sudo npm install -g vsce
+      - run:
+          name: npm-install
+          command: npm install
+      - run:
+          name: vsce-package
+          command: vsce package
+      - save_cache:
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - ./node_modules


### PR DESCRIPTION
- https://circleci.com/docs/2.0/migrating-from-travis/
- create a file almost from scratch
- use cimg/node instead of the "legacy" one mentioned in the migration
guide. it allows to specify lts
- global install needs to be done using `sudo`

Signed-off-by: Aurélien Pupier <apupier@redhat.com>