### PR TITLE
FUSETOOLS2-1299 - fix jenkins file to use main branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,8 @@
 node('rhel7'){
 	stage('Checkout repo') {
 		deleteDir()
-		git url: 'https://github.com/camel-tooling/vscode-camel-extension-pack.git'
+		git url: 'https://github.com/camel-tooling/vscode-camel-extension-pack.git',
+		    branch: 'main'
 	}
 
 	stage('Install requirements') {


### PR DESCRIPTION
the default branch for Jenkins git plugin is master
