### PR TITLE
FUSETOOLS2-1359 - avoid use of sudo to install global npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,17 +13,17 @@ jobs:
   build:
     working_directory: ~/vscode-camel-extension-pack
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:14.18
     steps:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: install-typescript
-          command: sudo npm install -g typescript
+          command: npm install --prefix=$HOME/.local -g typescript
       - run:
           name: install-vsce
-          command: sudo npm install -g vsce
+          command: npm install --prefix=$HOME/.local -g vsce
       - run:
           name: npm-install
           command: npm install


### PR DESCRIPTION
dependencies
on Circle CI

it was previously required, now it is causing build failures.
see https://stackoverflow.com/questions/50915469/simple-circleci-2-0-configuration-fails-for-global-npm-package-installation
for workaround

Signed-off-by: Aurélien Pupier <apupier@redhat.com>