### PR TITLE
FUSETOOLS2-1398 - remove keyword for wsdl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.0.11
 
+* Remove wsdl as keyword of the extension
+
 ## 0.0.10
 
 * Remove VS Code wsdl2rest as this extension is now deprecated

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
 		"Apache Camel",
 		"Camel",
 		"Fuse",
-		"Red Hat Fuse",
-		"wsdl"
+		"Red Hat Fuse"
 	]
 }


### PR DESCRIPTION
as the extension was deprecated and removed from the Extension Pack

Signed-off-by: Aurélien Pupier <apupier@redhat.com>