### PR TITLE
FUSETOOLS2-1513 - rhel 8 is now required

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('rhel7'){
+node('rhel8'){
 	stage('Checkout repo') {
 		deleteDir()
 		git url: 'https://github.com/camel-tooling/vscode-camel-extension-pack.git',
@@ -36,7 +36,7 @@ node('rhel7'){
 	}
 }
 
-node('rhel7'){
+node('rhel8'){
 	if(publishToMarketPlace.equals('true')){
 		timeout(time:5, unit:'DAYS') {
 			input message:'Approve deployment?', submitter: 'apupier,lheinema,bfitzpat,tsedmik,djelinek'


### PR DESCRIPTION
otherwise there is an error "No matching version found for
detect-libc@^2.0.0."

see https://studio-jenkins-csb-codeready.apps.ocp4.prod.psi.redhat.com/job/Fuse/job/VSCode/job/vscode-camel-lsp-extension-pack-release/34/ which is "replayed" with a modified script using rhel 8 instead of rhel 7