### PR TITLE
FUSETOOLS2-1587 - fix upload to download.jboss.org

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ node('rhel8'){
 	if(params.UPLOAD_LOCATION) {
 		stage('Snapshot') {
 			def filesToPush = findFiles(glob: '**.vsix')
-			sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${filesToPush[0].path} ${UPLOAD_LOCATION}/snapshots/vscode-camel-extension-pack/"
+			sh "sftp -C ${UPLOAD_LOCATION}/snapshots/vscode-camel-extension-pack/ <<< \$'put -p -r ${filesToPush[0].path}'"
 			stash name:'vsix', includes:filesToPush[0].path
 		}
 	}
@@ -52,7 +52,7 @@ node('rhel8'){
 
             stage "Promote the build to stable"
             def vsix = findFiles(glob: '**.vsix')
-            sh "rsync -Pzrlt --rsh=ssh --protocol=28 ${vsix[0].path} ${UPLOAD_LOCATION}/stable/vscode-camel-extension-pack/"
+            sh "sftp -C ${UPLOAD_LOCATION}/stable/vscode-camel-extension-pack/ <<< \$'put -p -r ${vsix[0].path}'"
             
             sh "npm install -g ovsx"
 		    withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {


### PR DESCRIPTION
rsync is now no more recommended and requires extra parameters.
Replacing by sftp which is the recommended way.

Following recommended PR on other project
https://github.com/redhat-developer/vscode-wizard/pull/103

Signed-off-by: Aurélien Pupier <apupier@redhat.com>