### PR TITLE
FUSETOOLS2-1566 - upgrade node on Circle CI to version 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     working_directory: ~/vscode-camel-extension-pack
     docker:
-      - image: cimg/node:14.18
+      - image: cimg/node:16.15
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>