### PR TITLE
FUSETOOLS2-1895 - remove @vscode/vsce global install on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,6 @@ node('rhel8'){
 	stage('Install requirements') {
 		def nodeHome = tool 'nodejs-lts'
 		env.PATH="${env.PATH}:${nodeHome}/bin"
-		sh "npm install -g typescript @vscode/vsce"
 	}
 
 	stage('Build') {


### PR DESCRIPTION
it is already provided by nodejs-lts tool. The migration to @vscode/vsce for this part will be done on Jenkins side
https://gitlab.cee.redhat.com/codeready-studio/cci-config/-/merge_requests/700