### PR TITLE
Fix main branch on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node('rhel8'){
 	}
 
 	stage('Install requirements') {
-		def nodeHome = tool 'nodejs-lts'
+		def nodeHome = tool 'nodejs-lts-16'
 		env.PATH="${env.PATH}:${nodeHome}/bin"
 	}
 


### PR DESCRIPTION
nodejs-lts has been upgraded from 16 to 18 on Jenkins CI Builds are very flaky with this version (5 out of 6 failures) forcing going back to Node 16 lts (even if out of support in few days)