### PR TITLE
Use Node to 20 in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node('rhel8'){
 	}
 
 	stage('Install requirements') {
-		def nodeHome = tool 'nodejs-lts'
+		def nodeHome = tool 'nodejs-lts-20'
 		env.PATH="${env.PATH}:${nodeHome}/bin"
 	}
 


### PR DESCRIPTION
it is now required by ovsx to publish on open-vsx Marketplace

error message:

```
09:29:26  + ovsx publish -p **** apache-camel-extension-pack-0.0.19-86.vsix
09:29:26  ovsx requires at least NodeJS version 20. Check your installed version with `node --version`.
```